### PR TITLE
Allowing image offset to be specified in config.toml (fixes issue #48)

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -680,13 +680,13 @@ async function downloadAndFlash(fileURL) {
 	let offset = 0x0000;
 	if ( strOffset !== undefined )
 	{
-		offset = parseInt(strOffset);
+	    offset = parseInt(strOffset);
 	}
     try {
         if (data !== undefined) {
             $('#v-pills-console-tab').click();
             const flashOptions = {
-				fileArray : [{data:data, address:offset}],
+		fileArray : [{data:data, address:offset}],
                 flashSize: "keep",
                 flashMode: undefined,
                 flashFreq: undefined,
@@ -694,10 +694,9 @@ async function downloadAndFlash(fileURL) {
                 compress: true,
             };
             await esploader.writeFlash(flashOptions);
-        }
-		else {
-			alert("Image file not found");
-		}
+        } else {
+	    alert("Image file not found");
+	}
     } catch (e) {
     }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -675,12 +675,18 @@ programButton.onclick = async () => {
 }
 
 async function downloadAndFlash(fileURL) {
-    let data = await utilities.getImageData(fileURL);
+	let data = await utilities.getImageData(fileURL);
+	let strOffset = config[deviceTypeSelect.value].offset;
+	let offset = 0x0000;
+	if ( strOffset !== undefined )
+	{
+		offset = parseInt(strOffset);
+	}
     try {
         if (data !== undefined) {
             $('#v-pills-console-tab').click();
             const flashOptions = {
-                fileArray : [{data:data, address:0x0000}],
+				fileArray : [{data:data, address:offset}],
                 flashSize: "keep",
                 flashMode: undefined,
                 flashFreq: undefined,
@@ -689,6 +695,9 @@ async function downloadAndFlash(fileURL) {
             };
             await esploader.writeFlash(flashOptions);
         }
+		else {
+			alert("Image file not found");
+		}
     } catch (e) {
     }
 }


### PR DESCRIPTION
Modified function downloadAndFlash to handle image offset. Image offset should be added to config.toml inside the section of the corresponding app. If offset is not specified it defaults to zero.
Also, added an alert if the image file is not found, because otherwise there is no warning to the user (but this should also be handled outside this function, to disable the flashing complete message).